### PR TITLE
remove file_get_contents

### DIFF
--- a/modules/attachment.php
+++ b/modules/attachment.php
@@ -27,7 +27,14 @@ class Attachment extends Base {
 			return false;
 		}
 
-		$bits = file_get_contents( $data['attachment_url'] );
+		$response = wp_remote_get( $data['attachment_url'], array( 'timeout' => 5 ) );
+
+		if( is_wp_error( $response ) ){
+			return false;
+		}
+
+		$bits = wp_remote_retrieve_body( $response );
+
 		$filename = $this->faker->uuid() . '.jpg';
 		$upload = wp_upload_bits( $filename, null, $bits );
 


### PR DESCRIPTION
uses wp_remote_get instead of file_get_contents for servers where `allow_url_fopen = off`.

Better use WordPress native methods to get the images so it works on more servers
